### PR TITLE
[Bugfix] Missing support for input metadata field specification

### DIFF
--- a/bin/tsc80.js
+++ b/bin/tsc80.js
@@ -83,7 +83,7 @@ function run() {
                 beautify: !cCompress['mangle'] && !cCompress['compress'],
                 indent_level: cCompress['indentLevel'],
                 comments: false,
-                preamble: "// title: " + cGame['title'] + "\n// author: " + cGame['author'] + "\n// desc: " + cGame['desc'] + "\n// script: js\n// input: " + cGame['input'] + "\n"
+                preamble: "// title: " + cGame['title'] + "\n// author: " + cGame['author'] + "\n// desc: " + cGame['desc'] + "\n// script: js\n" + (cGame['input'] && "// input: " + cGame['input'] + "\n")
             }
         });
         fs.writeFileSync(cCompress['compressedFile'], result.code);

--- a/bin/tsc80.js
+++ b/bin/tsc80.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 "use strict";
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", { value: true });
 var child_process = require("child_process");
 var path = require("path");
 var uglifyJS = require("uglify-js");

--- a/bin/tsc80.js
+++ b/bin/tsc80.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+exports.__esModule = true;
 var child_process = require("child_process");
 var path = require("path");
 var uglifyJS = require("uglify-js");
@@ -83,7 +83,7 @@ function run() {
                 beautify: !cCompress['mangle'] && !cCompress['compress'],
                 indent_level: cCompress['indentLevel'],
                 comments: false,
-                preamble: "// title: " + cGame['title'] + "\n// author: " + cGame['author'] + "\n// desc: " + cGame['desc'] + "\n// script: js\n"
+                preamble: "// title: " + cGame['title'] + "\n// author: " + cGame['author'] + "\n// desc: " + cGame['desc'] + "\n// script: js\n// input: " + cGame['input'] + "\n"
             }
         });
         fs.writeFileSync(cCompress['compressedFile'], result.code);

--- a/src/tsc80.ts
+++ b/src/tsc80.ts
@@ -102,7 +102,7 @@ function run() {
           beautify: !cCompress['mangle'] && !cCompress['compress'],
           indent_level: cCompress['indentLevel'],
           comments: false,
-          preamble: `// title: ${cGame['title']}\n// author: ${cGame['author']}\n// desc: ${cGame['desc']}\n// script: js\n// input: ${cGame['input']}\n`
+          preamble: `// title: ${cGame['title']}\n// author: ${cGame['author']}\n// desc: ${cGame['desc']}\n// script: js\n${cGame['input'] && `// input: ${cGame['input']}\n`}`
         }
       })
 

--- a/src/tsc80.ts
+++ b/src/tsc80.ts
@@ -102,7 +102,7 @@ function run() {
           beautify: !cCompress['mangle'] && !cCompress['compress'],
           indent_level: cCompress['indentLevel'],
           comments: false,
-          preamble: `// title: ${cGame['title']}\n// author: ${cGame['author']}\n// desc: ${cGame['desc']}\n// script: js\n`
+          preamble: `// title: ${cGame['title']}\n// author: ${cGame['author']}\n// desc: ${cGame['desc']}\n// script: js\n// input: ${cGame['input']}\n`
         }
       })
 


### PR DESCRIPTION
The user can now specify an `input` attribute the `game` object in `tsc80-config.json`.

If the field has a value, that value will be instantiated as any other metadata tag on the transpiled code. Otherwise it will not be instantiated, and TIC-80 will make it default to gamepad.