### PR TITLE
Add @noSelfInFile to definitions

### DIFF
--- a/tocopy/tic.d.ts
+++ b/tocopy/tic.d.ts
@@ -1,3 +1,5 @@
+/** @noSelfInFile */
+
 declare function btn(id: number): boolean;
 
 declare function btnp(id: number, hold?: number, period?: number): boolean;


### PR DESCRIPTION
When compiling on later versions of Typescript, calling `btn(0)` will result in `btn(nil, 0)`. This definition fixes that behavior to just use `btn(0)`.