### PR TITLE
When running the build command, exit the process upon completion

### DIFF
--- a/bin/tsc80.js
+++ b/bin/tsc80.js
@@ -162,6 +162,9 @@ function build(_a) {
             process.exit(0);
         }
         console.log("Build complete");
+        if (!run) {
+            process.exit(0);
+        }
     }
     function launchTIC() {
         var child = child_process.spawn(cTic.ticExecutable, [

--- a/src/tsc80.ts
+++ b/src/tsc80.ts
@@ -207,6 +207,10 @@ function build({ run = false }): void {
     }
 
     console.log("Build complete")
+
+    if(!run) {
+      process.exit(0);
+    }
   }
 
   function launchTIC() {


### PR DESCRIPTION
**What was happening**

After running `tsc80 build` the CLI was hanging after "Build Complete" and required a CTRL+C to get back to the command prompt.

**What I think should happen**

After successfully completing I believe the script should return to the CLI

**Why is this helpful**

I am writing some unit tests and would like to automatically run `tsc80 build` before going o n to run `npm test`