### PR TITLE
Fix race conditions and simplify watch code

### DIFF
--- a/src/tsc80.ts
+++ b/src/tsc80.ts
@@ -120,53 +120,36 @@ function build({ run = false }): void {
   } = config["compression"]
 
   const outFile: string = tsconfig["compilerOptions"]["outFile"]
+  const toWatch = path.join(process.cwd(), "**/*.ts")
 
-  // Watch changes
-  chokidar.watch(outFile).on("change", (path, stats) => {
-    try {
-      makeGameFile()
-    } catch (e) {
-      console.error(e)
-    }
-  })
+  if (run) {
+    // Watch changes
+    chokidar.watch(toWatch).on("change", () => {
+      try {
+        compileAndRun(false)
+      } catch (e) {
+        console.error(e)
+      }
+    }).on("ready", () => compileAndRun())
+  } else {
+    // Build once
+    compileAndRun()
+  }
+
+  function compileAndRun(launch = true) {
+    compile()
+    makeGameFile()
+    launch && launchTIC()
+  }
 
   function compile(): void {
     console.log("Compiling TypeScript...")
-
-    // Initial build
     child_process.execSync(`tsc`, { encoding: "utf-8" })
-    makeGameFile()
-
-    // Watching and rebuilding
-    if (run) {
-      child_process.exec(
-        "tsc --watch",
-        { encoding: "utf-8" },
-        (error, stdout, stderr) => {
-          if (stdout) {
-            console.log(stdout)
-          }
-          if (stderr) {
-            console.error(stderr)
-          }
-        }
-      )
-      launchTIC()
-    }
   }
 
   function makeGameFile(): void {
-
     console.log("Building game file...")
-    let buildStr: string
-    let tries = 0
-    do {
-      buildStr = fs.readFileSync(outFile, "utf8")
-      // Retry if the file is empty
-      if (++tries > 100) {
-        throw new Error("Unable to build game file.")
-      }
-    } while (buildStr.length < 10)
+    let buildStr = fs.readFileSync(outFile, "utf8")
 
     // Explicit strict mode breaks the global TIC scope
     buildStr = buildStr.replace('"use strict";', "")
@@ -207,10 +190,6 @@ function build({ run = false }): void {
     }
 
     console.log("Build complete")
-
-    if(!run) {
-      process.exit(0);
-    }
   }
 
   function launchTIC() {
@@ -232,6 +211,4 @@ function build({ run = false }): void {
       process.exit(code ?? 0)
     })
   }
-
-  compile()
 }


### PR DESCRIPTION
Hi. I noticed that you have code in makeGameFile to try and address race conditions resulting from running tsc in watch mode. Since you've already incorporated chokidar, you can streamline the process of rebuilding when changes occur and avoid using loop/retry logic to address this situation. This simplifies to code IMO and also makes it more reliable.

Also, I wanted to thank you for this project. It's awesome! I've used a lot your code as a basis for my own project which compiles TypeScript to PICO-8 Lua. The process is slightly different since PICO-8 doesn't support JavaScript natively. You can check out the project here if you're interested. It's still very much a work in progress.

https://github.com/tmountain/tic80-typescript